### PR TITLE
feature(admin-can-create-trips): Admin can create trips

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: node app.js
+heroku buildpacks: set heroku/node

--- a/app/development.log
+++ b/app/development.log
@@ -214,3 +214,11 @@ info [Thu Jul 11 2019 11:19:23 GMT+0100 (GMT Daylight Time)]  bus id is 9UngpDq4
 
 
 
+
+
+
+
+
+
+
+

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "codeclimate-coverage:dev": "set CODECLIMATE_REPO_TOKEN=3e7edd83e8b2cb79c3c7d161110866257359f27d8e82bf5402d00145c529ffa4 && codeclimate-test-reporter < lcov.info",
     "coverage": "nyc npm run test && npm run generate-lcov && npm run coveralls-coverage && npm run codeclimate-coverage",
     "coverage:dev": "nyc npm run test && npm run generate-lcov && npm run coveralls-coverage && npm run codeclimate-coverage:dev",
-    "build:dev": "rm -rf ./build && babel -d ./build ./app -s"
+    "build:dev": "rm -rf ./build && babel -d ./build ./app -s",
+    "heroku buildpacks": "set heroku/node"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As an Admin
I want to be able to create a trip
so that users can see trips

Acceptance Criteria: (presented as Scenarios)

Scenario: Create a Trip
Given Admin creates a trip
And there are users
When admin creates a trip
Then users can see the trip
And and everything works fine
Branch Name
ft-Admin-can-create-a-trip-167166048